### PR TITLE
Make DB/IMAP auth configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,9 @@ Z-Push backend to allow synchronisation of Roundcube contacts with ActiveSync en
 
 To use:
 - Set up Z-Push as normal.
-- Copy the file roundcubecontacts.php into the backend folder.
-- Open the Z-Push config.php file in a text editor.
-- Set BACKEND_PROVIDER to BackendRoundcubeContacts.
-- Add the following lines to the config.php file:
-```php
-define('ROUNDCUBE_CONTACT_DB_NAME','database');
-define('ROUNDCUBE_CONTACT_DB_USER','user');
-define('ROUNDCUBE_CONTACT_DB_PASS','password');
-define('ROUNDCUBE_CONTACT_DB_HOST','host');
-```
+- Create the backend/roundcubecontacts directory
+- Copy the file roundcubecontacts.php and config.php into the backend/roundcubecontacts folder.
+- Open the main Z-Push config.php file in a text editor.
+- Set BACKEND_PROVIDER to BackendRoundcubeContacts in the main config.php
+- Update backend/roundcubecontacts/config.php and set Rouncube's DB and choose what mechanism you want to use to authenticate users (either database or imap)
+

--- a/config.php
+++ b/config.php
@@ -1,0 +1,21 @@
+<?php
+# The database details of Roundcube's database
+define('ROUNDCUBE_CONTACT_DB_NAME',"roundcubemail");
+define('ROUNDCUBE_CONTACT_DB_USER',"user");
+define('ROUNDCUBE_CONTACT_DB_PASS',"password");
+define('ROUNDCUBE_CONTACT_DB_HOST',"host");
+
+# Use this section if you want to authenticate users against passwords in a database
+define('ROUNDCUBE_CONTACT_USER_AUTH','database');
+define('ROUNDCUBE_PASSWORD_SQL',"SELECT password FROM users WHERE username='%u'");
+define('ROUNDCUBE_AUTH_DB_NAME',"authdb");
+define('ROUNDCUBE_AUTH_DB_USER',"user");
+define('ROUNDCUBE_AUTH_DB_PASS',"password");
+define('ROUNDCUBE_AUTH_DB_HOST',"localhost");
+
+# Use this section if you want to use imap to authenticate users
+#define('ROUNDCUBE_CONTACT_USER_AUTH','imap');
+#define('ROUNDCUBE_CONTACT_IMAP_SERVER','{localhost:993/imap/ssl/novalidate-cert}');
+
+?>
+


### PR DESCRIPTION
Make DB/IMAP auth configurable
Update to DB auth to cope with Dovecot's weird password handling
Added GetSupportedASVersion() as that seems to be required by Z-Push now
Updated paths and config files as the backends now live in their own subdirectory, with their own config.php in there.
